### PR TITLE
Revise industries of interest in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <h2 align="left"> <img src="https://media.giphy.com/media/Es9WkET7QSjIItpbLA/giphy.gif" width="35px">&nbsp; About Me 🤵</h2>
 
-- 👀 As a BI & Analytics Engineer as well as a dedicated lifelong learner, I’m interested in Data Engineering, Business Intelligence, Agentic Development & AGI, CAE (automotive, mechanical & aerospace industries), DeFi & CeFi, and road cycling.
+- 👀 As a BI & Analytics Engineer as well as a dedicated lifelong learner, I’m interested in Data Engineering, Business Intelligence, Agentic Development & AGI, CAE (DaaS, SaaS, e-commerce, automotive, mechanical & aerospace industries), DeFi & CeFi, and road cycling.
 
      <details>
      <summary> 🏎️ Megacar: Koenigsegg CC850 FTW 🔊 </summary>


### PR DESCRIPTION
Updated the industries of interest in the About Me section.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/pizofreude/pizofreude/pull/69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

## Summary by Sourcery

Documentation:
- Revise the README About Me text to list updated CAE domains, including DaaS, SaaS, and e-commerce.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated interests list to include DaaS, SaaS, and e-commerce in addition to existing CAE industry interests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->